### PR TITLE
src: add missing headers for size_t and errno definitions

### DIFF
--- a/src/adler32.h
+++ b/src/adler32.h
@@ -1,6 +1,7 @@
 #if !defined(__ADLER32_H)
 #define __ADLER32_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #define DEFAULT_ADLER32 1

--- a/src/blake2b.h
+++ b/src/blake2b.h
@@ -1,6 +1,7 @@
 #if !defined(__BLAKE2B_H)
 #define __BLAKE2B_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct {

--- a/src/cha2slide.c
+++ b/src/cha2slide.c
@@ -10,6 +10,7 @@ cha2slide decrypt out.enc alt.png test
 
 */
 
+#include <errno.h>
 #include <getopt.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Required a least on macOS.